### PR TITLE
Fix issue where builds were running twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,14 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run
+      # this job on pull_request events for branches that look like fork
+      # branches. Without this we would end up running this job twice for non
+      # forked PRs, once for the push and then once for opening the PR.
+      # See https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
+    - '**:**'
 jobs:
   build:
     name: UTs ${{ matrix.os }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,5 +1,14 @@
 name: FTs
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run
+      # this job on pull_request events for branches that look like fork
+      # branches. Without this we would end up running this job twice for non
+      # forked PRs, once for the push and then once for opening the PR.
+      # See https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
+    - '**:**'
 jobs:
 
   functional-tests:


### PR DESCRIPTION
The builds were running on every push and every pull request
change, meaning that when opening or editing a pull request they were
running twice, at the same time.  This could lead to unexpected
results.

Solution is to [only run them on pull requests which come from a
fork][1].

[1]: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10?