### PR TITLE
Enable Codespaces & VS Code Remote as IDEs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@
 ARG VARIANT=15
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
+COPY library-scripts/* /tmp/scripts/
+
 # [Option] Install Maven
 ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=""
@@ -15,6 +17,10 @@ RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install Go and remove script now that we're done with it
+RUN bash /tmp/scripts/go-debian.sh "latest" "${GOROOT}" "${GOPATH}" "${USERNAME}" \
+    && apt-get clean -y && rm -rf /tmp/scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+# [Choice] Java version: 11, 15
+ARG VARIANT=15
+FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
+
+# [Option] Install Maven
+ARG INSTALL_MAVEN="false"
+ARG MAVEN_VERSION=""
+# [Option] Install Gradle
+ARG INSTALL_GRADLE="false"
+ARG GRADLE_VERSION=""
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
+    && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,14 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 RUN bash /tmp/scripts/go-debian.sh "latest" "${GOROOT}" "${GOPATH}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /tmp/scripts
 
+# Install Gauge
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -SsL https://downloads.gauge.org/stable | sh \
+    && su vscode -c "gauge install java" \
+    && su vscode -c "gauge install html-report" \
+    && su vscode -c "gauge install screenshot" \
+    && su vscode -c "gauge install xml-report"
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,22 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go",
+		"go.useLanguageServer": true,
+		"go.goroot": "/usr/local/go",
+		"go.toolsGopath": "/go/bin",
+		"go.lintTool":"golangci-lint",
+		"go.lintFlags": [ "--fast" ],
+		"workbench.colorTheme": "Default Dark+",
+		"files.autoSave": "afterDelay",
+		"files.autoSaveDelay": 500,
 		"java.home": "/docker-java-home"
 	},
 	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
+		"golang.Go",
+		"getgauge.gauge",
 		"vscjava.vscode-java-pack"
 	],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+	"name": "Java",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a Java version: 11, 15
+			"VARIANT": "15",
+			// Options
+			"INSTALL_MAVEN": "false",
+			"INSTALL_GRADLE": "true",
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home"
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vscjava.vscode-java-pack"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/library-scripts/go-debian.sh
+++ b/.devcontainer/library-scripts/go-debian.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+#
+# Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]
+
+TARGET_GO_VERSION=${1:-"latest"}
+TARGET_GOROOT=${2:-"/usr/local/go"}
+TARGET_GOPATH=${3:-"/go"}
+USERNAME=${4:-"automatic"}
+UPDATE_RC=${5:-"true"}
+INSTALL_GO_TOOLS=${6:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+function updaterc() {
+    if [ "${UPDATE_RC}" = "true" ]; then
+        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+        echo -e "$1" | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, tar, git, other dependencies if missing
+if ! dpkg -s curl ca-certificates tar git g++ gcc libc6-dev make pkg-config > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends curl ca-certificates tar git g++ gcc libc6-dev make pkg-config
+fi
+
+# Get latest version number if latest is specified
+if [ "${TARGET_GO_VERSION}" = "latest" ] ||  [ "${TARGET_GO_VERSION}" = "current" ] ||  [ "${TARGET_GO_VERSION}" = "lts" ]; then
+    TARGET_GO_VERSION=$(curl -sSL "https://golang.org/VERSION?m=text" | sed -n '/^go/s///p' )
+fi
+
+# Install Go
+GO_INSTALL_SCRIPT="$(cat <<EOF
+    set -e
+    echo "Downloading Go ${TARGET_GO_VERSION}..."
+    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-amd64.tar.gz"
+    echo "Extracting Go ${TARGET_GO_VERSION}..."
+    tar -xzf /tmp/go.tar.gz -C "${TARGET_GOROOT}" --strip-components=1
+    rm -f /tmp/go.tar.gz
+EOF
+)"
+if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
+    mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}" 
+    chown -R ${USERNAME} "${TARGET_GOROOT}" "${TARGET_GOPATH}"
+    su ${USERNAME} -c "${GO_INSTALL_SCRIPT}"
+else
+    echo "Go already installed. Skipping."
+fi
+
+# Install Go tools
+GO_TOOLS_WITH_MODULES="\
+    golang.org/x/tools/gopls \
+    honnef.co/go/tools/... \
+    golang.org/x/tools/cmd/gorename \
+    golang.org/x/tools/cmd/goimports \
+    golang.org/x/tools/cmd/guru \
+    golang.org/x/lint/golint \
+    github.com/mdempsky/gocode \
+    github.com/cweill/gotests/... \
+    github.com/haya14busa/goplay/cmd/goplay \
+    github.com/sqs/goreturns \
+    github.com/josharian/impl \
+    github.com/davidrjenni/reftools/cmd/fillstruct \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    github.com/godoctor/godoctor \
+    github.com/rogpeppe/godef \
+    github.com/zmb3/gogetdoc \
+    github.com/fatih/gomodifytags \
+    github.com/mgechev/revive \
+    github.com/go-delve/delve/cmd/dlv"
+if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
+    echo "Installing common Go tools..."
+    export PATH=${TARGET_GOROOT}/bin:${PATH}
+    mkdir -p /tmp/gotools
+    cd /tmp/gotools
+    export GOPATH=/tmp/gotools
+    export GOCACHE=/tmp/gotools/cache
+
+    # Go tools w/module support
+    export GO111MODULE=on
+    (echo "${GO_TOOLS_WITH_MODULES}" | xargs -n 1 go get -v )2>&1
+
+    # gocode-gomod
+    export GO111MODULE=auto
+    go get -v -d github.com/stamblerre/gocode 2>&1
+    go build -o gocode-gomod github.com/stamblerre/gocode
+
+    # golangci-lint
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${TARGET_GOPATH}/bin 2>&1
+
+    # Move Go tools into path and clean up
+    mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
+    mv gocode-gomod ${TARGET_GOPATH}/bin/
+    rm -rf /tmp/gotools
+    chown -R ${USERNAME} "${TARGET_GOPATH}"
+fi
+
+# Add GOPATH variable and bin directory into PATH in bashrc/zshrc files (unless disabled)
+updaterc "$(cat << EOF
+export GOPATH="${TARGET_GOPATH}"
+if [[ "\${PATH}" != *"\${GOPATH}/bin"* ]]; then export PATH="\${PATH}:\${GOPATH}/bin"; fi
+export GOROOT="${TARGET_GOROOT}"
+if [[ "\${PATH}" != *"\${GOROOT}/bin"* ]]; then export PATH="\${PATH}:\${GOROOT}/bin"; fi
+EOF
+)"
+
+
+echo "Done!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# How to contribute
+
+Firstly thanks for thinking of contributing - the project is [open source](https://opensource.guide/how-to-contribute/) and all contributions are very welcome :slightly_smiling_face: :boom: :thumbsup:
+
+[How to report a bug or suggest a new feature](#how-to-report-a-bug-or-suggest-a-new-feature)
+
+[How to make a contribution](#how-to-make-a-contribution)
+
+[Local development](#local-development)
+  * [Visual Studio Code](#visual-studio-code)
+  * [Codespaces](#codespaces)
+  * [Local development from scratch](#local-development-from-scratch)
+    * [Dependencies](#dependencies)
+
+[Functional tests](./functional-tests/README.md)
+
+## How to report a bug or suggest a new feature
+
+[Create an issue](../../issues), describing the bug or new feature in as much detail as you can.
+
+## How to make a contribution
+
+  * [Create an issue](../../issues) describing the change you are proposing.
+  * [Create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).  The project uses the _[fork and pull model](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-collaborative-development-models)_:
+    * [Fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks)
+    * Make your changes on your fork
+        * [Update the tests or add new tests](./functional-tests/README.md) to cover the new behaviour.
+    * Write a [good commit message(s)](https://chris.beams.io/posts/git-commit/) for your changes
+    * [Create the pull request for your changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)
+
+### Visual Studio Code
+
+The easiest way to set up your development environment (unless you have [Codespaces](#codespaces), which is even easier) is to use [Visual Studio Code](https://code.visualstudio.com/)'s [Remote Containers](https://code.visualstudio.com/docs/remote/containers) functionality:
+  * [System requirements](https://code.visualstudio.com/docs/remote/containers#_system-requirements)
+  * [Fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks) 
+  * [Open the local project folder in a container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
+  * Everything will then be setup for you.  You'll be able to [run the tests](./functional-tests/README.md) locally.
+
+### Codespaces
+
+If you have access to [GitHub Codespaces](https://github.com/features/codespaces/) (which allows full remote
+development from within your browser or VS Code) then all you need to do is 
+[fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks) 
+and open it in Codespaces - easy!
+
+### Local development from scratch
+
+#### Dependencies
+
+* [Go](https://golang.org)
+* [Java](https://www.java.com) version 15 or above (for [running the tests](./functional-tests/README.md))
+* [Gauge](https://gauge.org)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ In the following image, the specs/scenarios are filtered using a tag expression(
 <img src="https://github.com/getgauge/spectacle/raw/master/images/filter_tags.png" alt="filter" style="width: 600px;"/>
 
 
+Contributing
+------------
+
+See the [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 License
 -------


### PR DESCRIPTION
* [GitHub Codespaces][1] provides an instant dev environment in the 
   cloud with all dependencies installed and ready to go.

  [VS Code Remote Development][2] allows the use of a container, 
  remote machine, or the Windows Subsystem for Linux (WSL) as a 
  full-featured development environment.

  This commit sets up the [standard Java remote container][3] with 
  Java 15 and Gradle installed.

[1]: https://github.com/features/codespaces/
[2]: https://code.visualstudio.com/docs/remote/remote-overview
[3]: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java

* Add Go to devcontainer

* Install Gauge and add Go settings on devcontainer

* Document how to make contributions