### PR TITLE
Add spec replacement contract test

### DIFF
--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -49,15 +49,20 @@ func (i *issue) jiraFmtSpecs() string {
 }
 
 func (i *issue) currentDescriptionWithExistingSpecsRemoved() (string, error) {
-	regexString := fmt.Sprintf("(?s)%s(.*)%s", i.specsHeader(), i.specsFooter())
-	r := regexp.MustCompile(regexString)
 	currentDescription, err := i.currentDescription()
 
 	if err != nil {
 		return "", err
 	}
 
-	removed := r.ReplaceAllString(currentDescription, "\n")
+	return i.removeSpecsFrom(currentDescription)
+}
+
+func (i *issue) removeSpecsFrom(input string) (string, error) {
+	regexString := fmt.Sprintf("(?s)%s(.*)%s", i.specsHeader(), i.specsFooter())
+	r := regexp.MustCompile(regexString)
+
+	removed := r.ReplaceAllString(input, "\n")
 
 	if strings.TrimSpace(removed) == "" {
 		return "", nil

--- a/internal/jira/issue_test.go
+++ b/internal/jira/issue_test.go
@@ -1,0 +1,41 @@
+package jira
+
+import (
+	"testing"
+)
+
+func TestSpecsHeaderContract(t *testing.T) {
+	issue := issue{nil, ""}
+	input := `
+This is a description of an issue.
+----
+----
+h2.Specification Examples
+the spec
+----
+End of specification examples
+----
+----
+More description after the specs.`
+
+	expected := `
+This is a description of an issue.
+
+More description after the specs.`
+
+	actual, _ := issue.removeSpecsFrom(input)
+
+	if expected != actual {
+		t.Fatalf(`
+The contract for replacing specs in the issue description has changed. This would be a breaking change, as it would
+mean that existing users with Gauge specifications already published to Jira would not have these existing 
+specifications replaced when running the plugin.  Recommended solution therefore is to revert the change to the
+contract for replacing specs in the issue description.
+
+Expected
+%s
+
+but got:
+%s`, expected, actual)
+	}
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "jira",
-    "version" : "0.1.0",
+    "version" : "0.1.1",
     "name" : "Jira",
     "description" : "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
It is important that the contract to replace Gauge specifications in the
Jira issue descriptions does not change.  It would be a breaking change
if it did, as it would mean that existing users with Gauge specs already
published to Jira would not have these existing specifications replaced
when running the plugin.

This pull request therefore adds a test to verify that the contract for
replacing Gauge specifications in the Jira issue descriptions remains
unchanged.