### PR TITLE
Test entire console output to strengthen tests

### DIFF
--- a/functional-tests/specs/existing_description.spec
+++ b/functional-tests/specs/existing_description.spec
@@ -14,7 +14,7 @@ Basic Jira spec
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Jira issue "JIRAGAUGE-5" description should contain "Original description\nsome more text" and basic scenario
 

--- a/functional-tests/specs/no_jira_specs.spec
+++ b/functional-tests/specs/no_jira_specs.spec
@@ -19,4 +19,4 @@ Basic spec
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "No valid Jira specifications were found - so nothing to publish to Jira"
+* Console output should be "No valid Jira specifications were found - so nothing to publish to Jira"

--- a/functional-tests/specs/one_scenario.spec
+++ b/functional-tests/specs/one_scenario.spec
@@ -12,7 +12,7 @@ Basic Jira spec
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Jira issue "JIRAGAUGE-1" description should contain basic scenario
 

--- a/functional-tests/specs/publish_twice.spec
+++ b/functional-tests/specs/publish_twice.spec
@@ -12,11 +12,11 @@ Existing specs already in a Jira issue are overwritten when publishing
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Jira issue "JIRAGAUGE-7" description should contain basic scenario
 

--- a/functional-tests/specs/spec_linked_to_two_issues.spec
+++ b/functional-tests/specs/spec_linked_to_two_issues.spec
@@ -12,7 +12,7 @@ Basic Jira spec linked to two Jira issues
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 2 Jira issues"
+* Console output should be "Published specifications to 2 Jira issues"
 
 * Jira issue "JIRAGAUGE-3" description should contain basic scenario named "JIRAGAUGE-3, JIRAGAUGE-4"
 

--- a/functional-tests/specs/two_scenarios.spec
+++ b/functional-tests/specs/two_scenarios.spec
@@ -14,7 +14,7 @@ Basic Jira spec with two scenarios, linked to same issue
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Jira issue "JIRAGAUGE-2" description should contain basic scenario, twice
 

--- a/functional-tests/specs/two_specs_linked_to_same_issue.spec
+++ b/functional-tests/specs/two_specs_linked_to_same_issue.spec
@@ -14,7 +14,7 @@ Two specs linked to same Jira issue
 
 * Publish Jira Documentation for the current project
 
-* Console should contain "Published specifications to 1 Jira issue"
+* Console output should be "Published specifications to 1 Jira issue"
 
 * Jira issue "JIRAGAUGE-6" description should contain basic scenarios "first spec linked to JIRAGAUGE-6", "second spec linked to JIRAGAUGE-6"
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Console.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Console.java
@@ -14,4 +14,10 @@ public class Console {
         String output = getCurrentProject().getStdOut();
         assertThat(output).contains(message);
     }
+
+    @Step({"Console output should be <message>"})
+    public void consoleOutputShouldBe(String message) throws IOException {
+        String output = getCurrentProject().getStdOut();
+        assertThat(output.trim()).isEqualTo(message);
+    }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jira",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "name": "Jira",
     "description": "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
Checking the entire console output rather than just part of it is gives
us more regression coverage.

The console output sometimes differs on Jira Cloud from Jira Server,
because for instance the error messages logged on the console differ. So
we check the entire console output only for those scenarios which do not
differ on Jira Cloud and Server.