### PR TITLE
Prevent publishing when issue is in invalid state

### DIFF
--- a/functional-tests/specs/issue_in_invalid_state.spec
+++ b/functional-tests/specs/issue_in_invalid_state.spec
@@ -1,0 +1,33 @@
+# Jira issue with description that is in an invalid state
+
+tags: java, dotnet, ruby, python, js
+
+* Initialize an empty Gauge project
+
+## Jira issue with description that is in an invalid state
+
+Jira issues should only ever contain one Gauge examples section, currently (NB we may change this in
+the future if we cater for more than one source repo separately publishing their Gauge specs to the
+same Jira issue).
+
+This test ensures that we prevent publishing of specs to a Jira issue which is in an invalid state
+because it has more than one Gauge examples section in the Jira issue description.
+
+A Jira issue could get into this invalid state either because of a manual edit, or because of a bug
+(hypothetically) in the Gauge Jira plugin itself which inadvertently led to a duplicate examples
+section instead of replacing the existing one.
+
+* Set invalid description (with two Gauge sections) on Jira issue "JIRAGAUGE-10"
+
+* Create a scenario linked to Jira issue(s) "JIRAGAUGE-10"
+
+* Publish Jira Documentation for the current project
+
+* Console should contain "JIRAGAUGE-10 is in an invalid state."
+* Console should contain "It contains more than one Gauge examples section, but there should only ever be one or none."
+* Console should contain "Remove all Gauge example sections from JIRAGAUGE-10 in Jira manually and then rerun the Gauge Jira plugin"
+* Console should contain "No valid Jira specifications were found - so nothing to publish to Jira"
+
+___
+
+* Clear description on Jira issue "JIRAGAUGE-10"

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
@@ -10,17 +10,18 @@ public class Jira {
 
     @Step("Jira issue <issuekey> description should contain basic scenario named <scenario name>")
     public void verifyJiraIssueDescriptionForBasicScenario(String issueKey, String scenarioName) {
-        String expectedScenario = expectedExamplesHeader() + expectedBasicScenarioHeader(scenarioName) 
-            + expectedBasicSpec() +  expectedBasicScenarioFooter() + expectedExamplesFooter();
+        String expectedScenario = expectedExamplesHeader() + expectedBasicScenarioHeader(scenarioName)
+                + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedExamplesFooter();
         String issueDescription = getDescriptionForIssue(issueKey);
         assertThat(issueDescription).isEqualTo(expectedScenario);
     }
 
     @Step("Jira issue <issuekey> description should contain <originalDescription> and basic scenario")
-    public void verifyJiraIssueContainsOriginalDescriptionAndBasicScenario(String issueKey, String originalDescription) {
+    public void verifyJiraIssueContainsOriginalDescriptionAndBasicScenario(String issueKey,
+            String originalDescription) {
         String expectedScenario = expectedOriginalDescription(originalDescription) + expectedExamplesHeader()
-            + expectedBasicScenarioHeader(issueKey) + expectedBasicSpec() + expectedBasicScenarioFooter() 
-            + expectedExamplesFooter();
+                + expectedBasicScenarioHeader(issueKey) + expectedBasicSpec() + expectedBasicScenarioFooter()
+                + expectedExamplesFooter();
         String issueDescription = getDescriptionForIssue(issueKey);
         assertThat(issueDescription).isEqualTo(expectedScenario);
     }
@@ -32,18 +33,17 @@ public class Jira {
 
     @Step("Jira issue <issuekey> description should contain basic scenario, twice")
     public void verifyJiraIssueDescriptionForTwoBasicScenarios(String issueKey) {
-        String expectedScenario = expectedExamplesHeader() + expectedBasicScenarioHeader(issueKey)
-            + expectedBasicSpec() + expectedBasicSpec()
-            + expectedBasicScenarioFooter() + expectedExamplesFooter();
+        String expectedScenario = expectedExamplesHeader() + expectedBasicScenarioHeader(issueKey) + expectedBasicSpec()
+                + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedExamplesFooter();
         String issueDescription = getDescriptionForIssue(issueKey);
         assertThat(issueDescription).isEqualTo(expectedScenario);
     }
 
     @Step("Jira issue <issuekey> description should contain basic scenarios <scenario1>, <scenario2>")
     public void verifyJiraIssueDescriptionForTwoBasicScenarios(String issueKey, String scenario1, String scenario2) {
-        String expectedDescription = expectedExamplesHeader() + expectedBasicScenarioHeader(scenario1) 
-            + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedBasicScenarioHeader(scenario2) 
-            + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedExamplesFooter();
+        String expectedDescription = expectedExamplesHeader() + expectedBasicScenarioHeader(scenario1)
+                + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedBasicScenarioHeader(scenario2)
+                + expectedBasicSpec() + expectedBasicScenarioFooter() + expectedExamplesFooter();
         String issueDescription = getDescriptionForIssue(issueKey);
         assertThat(issueDescription).isEqualTo(expectedDescription);
     }
@@ -53,58 +53,66 @@ public class Jira {
         setIssueDescription(description, issueKey);
     }
 
+    @Step("Set invalid description (with two Gauge sections) on Jira issue <issuekey>")
+    public void setInvalidDescriptionWithTwoGaugeSections(String issueKey) {
+        String exampleSection = expectedExamplesHeader() + expectedBasicScenarioHeader(issueKey) + expectedBasicSpec()
+                + expectedBasicScenarioFooter() + expectedExamplesFooter();
+        String invalidDescriptionWithTwoGaugeSections = exampleSection + exampleSection;
+        setIssueDescription(invalidDescriptionWithTwoGaugeSections, issueKey);
+    }
+
     private String expectedExamplesHeader() {
         return """
-        ----
-        ----
-        h2.Specification Examples
-        h3.Do not edit these examples here.  Edit them using Gauge.
-        """;
+                ----
+                ----
+                h2.Specification Examples
+                h3.Do not edit these examples here.  Edit them using Gauge.
+                """;
     }
 
     private String expectedExamplesFooter() {
         return """
-            ----
-            End of specification examples
-            ----
-            ----
-            """;
+                ----
+                End of specification examples
+                ----
+                ----
+                """;
     }
 
     private String expectedOriginalDescription(String originalDescription) {
         return """
-            %s
-            """.formatted(originalDescription);
+                %s
+                """.formatted(originalDescription);
     }
 
     private String expectedBasicScenarioHeader(String scenarioName) {
         return """
-            ----
-            h3. %s
+                ----
+                h3. %s
 
-            tags:\040
+                tags:\040
 
-            """.formatted(scenarioName);
+                """.formatted(scenarioName);
     }
 
     private String expectedBasicSpec() {
         return """
-            h4. Sample scenario
+                h4. Sample scenario
 
-            * First step
-            * Second step
-            * Third step
-            * Step with "two" "params"
+                * First step
+                * Second step
+                * Third step
+                * Step with "two" "params"
 
-            """;
+                """;
     }
 
     private String expectedBasicScenarioFooter() {
         return """
 
-            *_*
+                *_*
 
-            """;
+                """;
     }
-    
+
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jira",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "name": "Jira",
     "description": "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
Jira issues should only ever contain one Gauge examples section,
currently (NB we may change this in the future if we cater for more than
one source repo separately publishing their Gauge specs to the same
Jira issue).

This commit prevents publishing of specs to a Jira issue which is in an
invalid state because it has more than one Gauge examples section in the
Jira issue description.

A Jira issue could get into this invalid state either because of a
manual edit, or because of a bug (hypothetically) in the Gauge Jira
plugin itself which inadvertently led to a duplicate examples section
instead of replacing the existing one.