### PR TITLE
Fix duplicate Gauge examples section bug

### DIFF
--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
@@ -63,6 +63,7 @@ public class Jira {
 
     private String expectedExamplesHeader() {
         return """
+                
                 ----
                 ----
                 h2.Specification Examples

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
@@ -63,7 +63,7 @@ public class Jira {
 
     private String expectedExamplesHeader() {
         return """
-                
+
                 ----
                 ----
                 h2.Specification Examples
@@ -73,6 +73,7 @@ public class Jira {
 
     private String expectedExamplesFooter() {
         return """
+
                 ----
                 End of specification examples
                 ----

--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -12,10 +12,11 @@ const (
 	specsHeaderMessage = "Specification Examples"
 	// Jira sometimes adds or removes a space after the heading, so we need to cater for both scenarios
 	specsHeaderMessageRegex = "h2.\\s*" + specsHeaderMessage
-	specsHeader             = "----\n----\nh2." + specsHeaderMessage + "\n"
-	specsHeaderRegex        = "----\n----\n" + specsHeaderMessageRegex + "\n"
+	specsHeader             = "\n----\n----\nh2." + specsHeaderMessage + "\n"
+	specsHeaderRegex        = "\\s*----\\s*----\\s*" + specsHeaderMessageRegex + "\\s*"
 	specsSubheader          = "h3.Do not edit these examples here.  Edit them using Gauge.\n"
 	specsFooter             = "----\nEnd of specification examples\n----\n----\n"
+	specsFooterRegex        = "----\\s*End of specification examples\\s*----\\s*----\\s*"
 )
 
 type issue struct {
@@ -57,7 +58,7 @@ func (i *issue) currentDescriptionWithExistingSpecsRemoved() (string, error) {
 }
 
 func (i *issue) removeSpecsFrom(input string) (string, error) {
-	regexString := fmt.Sprintf("(?s)%s(.*)%s", specsHeaderRegex, specsFooter)
+	regexString := fmt.Sprintf("(?s)%s(.*)%s", specsHeaderRegex, specsFooterRegex)
 	r := regexp.MustCompile(regexString)
 
 	removed := r.ReplaceAllString(input, "\n")

--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/agilepathway/gauge-jira/internal/json"
+	"github.com/agilepathway/gauge-jira/internal/regex"
 )
 
 const (
@@ -102,8 +103,5 @@ type description string
 // (hypothetically) in the Gauge Jira plugin itself which inadvertently led to a duplicate examples
 // section instead of replacing the existing one.
 func (desc description) isValid() bool {
-	regex := regexp.MustCompile(specsHeaderRegex)
-	matches := regex.FindAllStringIndex(string(desc), -1)
-
-	return len(matches) < 2 //nolint:gomnd
+	return regex.CountMatches(string(desc), specsHeaderRegex) < 2 //nolint:gomnd
 }

--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -9,10 +9,13 @@ import (
 )
 
 const (
-	specsHeaderMessage = "h2.Specification Examples"
-	specsHeader        = "----\n----\n" + specsHeaderMessage + "\n"
-	specsSubheader     = "h3.Do not edit these examples here.  Edit them using Gauge.\n"
-	specsFooter        = "----\nEnd of specification examples\n----\n----\n"
+	specsHeaderMessage = "Specification Examples"
+	// Jira sometimes adds or removes a space after the heading, so we need to cater for both scenarios
+	specsHeaderMessageRegex = "h2.\\s*" + specsHeaderMessage
+	specsHeader             = "----\n----\nh2." + specsHeaderMessage + "\n"
+	specsHeaderRegex        = "----\n----\n" + specsHeaderMessageRegex + "\n"
+	specsSubheader          = "h3.Do not edit these examples here.  Edit them using Gauge.\n"
+	specsFooter             = "----\nEnd of specification examples\n----\n----\n"
 )
 
 type issue struct {
@@ -54,7 +57,7 @@ func (i *issue) currentDescriptionWithExistingSpecsRemoved() (string, error) {
 }
 
 func (i *issue) removeSpecsFrom(input string) (string, error) {
-	regexString := fmt.Sprintf("(?s)%s(.*)%s", specsHeader, specsFooter)
+	regexString := fmt.Sprintf("(?s)%s(.*)%s", specsHeaderRegex, specsFooter)
 	r := regexp.MustCompile(regexString)
 
 	removed := r.ReplaceAllString(input, "\n")
@@ -98,5 +101,8 @@ type description string
 // (hypothetically) in the Gauge Jira plugin itself which inadvertently led to a duplicate examples
 // section instead of replacing the existing one.
 func (desc description) isValid() bool {
-	return strings.Count(string(desc), specsHeaderMessage) < 2 //nolint:gomnd
+	regex := regexp.MustCompile(specsHeaderRegex)
+	matches := regex.FindAllStringIndex(string(desc), -1)
+
+	return len(matches) < 2 //nolint:gomnd
 }

--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -15,8 +15,8 @@ const (
 	specsHeader             = "\n----\n----\nh2." + specsHeaderMessage + "\n"
 	specsHeaderRegex        = "\\s*----\\s*----\\s*" + specsHeaderMessageRegex + "\\s*"
 	specsSubheader          = "h3.Do not edit these examples here.  Edit them using Gauge.\n"
-	specsFooter             = "----\nEnd of specification examples\n----\n----\n"
-	specsFooterRegex        = "----\\s*End of specification examples\\s*----\\s*----\\s*"
+	specsFooter             = "\n----\nEnd of specification examples\n----\n----\n"
+	specsFooterRegex        = "\\s*----\\s*End of specification examples\\s*----\\s*----\\s*"
 )
 
 type issue struct {

--- a/internal/jira/issue_test.go
+++ b/internal/jira/issue_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 )
 
-func TestSpecsHeaderContract(t *testing.T) {
-	issue := issue{nil, ""}
-	input := `
+const (
+	inputWithNoSpaceAfterH2 = `
 This is a description of an issue.
 ----
 ----
@@ -17,25 +16,59 @@ End of specification examples
 ----
 ----
 More description after the specs.`
+	inputWithSingleSpaceAfterH2 = `
+This is a description of an issue.
+----
+----
+h2. Specification Examples
+the spec
+----
+End of specification examples
+----
+----
+More description after the specs.`
+	inputWithMultipleSpacesAfterH2 = `
+This is a description of an issue.
+----
+----
+h2.        Specification Examples
+the spec
+----
+End of specification examples
+----
+----
+More description after the specs.`
+)
 
-	expected := `
+var issueTests = []struct { //nolint:gochecknoglobals
+	input string
+}{
+	{inputWithNoSpaceAfterH2},
+	{inputWithSingleSpaceAfterH2},
+	{inputWithMultipleSpacesAfterH2},
+}
+
+func TestSpecsHeaderContract(t *testing.T) {
+	for _, tt := range issueTests {
+		issue := issue{nil, ""}
+		expected := `
 This is a description of an issue.
 
 More description after the specs.`
+		actual, _ := issue.removeSpecsFrom(tt.input)
 
-	actual, _ := issue.removeSpecsFrom(input)
-
-	if expected != actual {
-		t.Fatalf(`
-The contract for replacing specs in the issue description has changed. This would be a breaking change, as it would
-mean that existing users with Gauge specifications already published to Jira would not have these existing 
-specifications replaced when running the plugin.  Recommended solution therefore is to revert the change to the
-contract for replacing specs in the issue description.
-
-Expected
-%s
-
-but got:
-%s`, expected, actual)
+		if expected != actual {
+			t.Fatalf(`
+	The contract for replacing specs in the issue description has changed. This would be a breaking change, as it would
+	mean that existing users with Gauge specifications already published to Jira would not have these existing 
+	specifications replaced when running the plugin.  Recommended solution therefore is to revert the change to the
+	contract for replacing specs in the issue description.
+	
+	Expected
+	%s
+	
+	but got:
+	%s`, expected, actual)
+		}
 	}
 }

--- a/internal/jira/issue_test.go
+++ b/internal/jira/issue_test.go
@@ -38,6 +38,59 @@ End of specification examples
 ----
 ----
 More description after the specs.`
+	inputWithLineBreaksBetweenRules = `
+This is a description of an issue.
+----
+
+----
+h2.        Specification Examples
+the spec
+----
+End of specification examples
+----
+
+----
+More description after the specs.`
+	inputWithLineBreaksBeforeAndAfter = `
+This is a description of an issue.
+
+
+----
+----
+h2.        Specification Examples
+the spec
+----
+End of specification examples
+----
+----
+
+
+More description after the specs.`
+	inputWithLineBreaksBetweenRulesAndSpecs = `
+This is a description of an issue.
+----
+----
+
+h2.        Specification Examples
+the spec
+
+----
+End of specification examples
+----
+----
+More description after the specs.`
+	inputWithLineBreakAfterFooter = `
+This is a description of an issue.
+----
+----
+h2.        Specification Examples
+the spec
+----
+End of specification examples
+
+----
+----
+More description after the specs.`
 )
 
 var issueTests = []struct { //nolint:gochecknoglobals
@@ -46,6 +99,10 @@ var issueTests = []struct { //nolint:gochecknoglobals
 	{inputWithNoSpaceAfterH2},
 	{inputWithSingleSpaceAfterH2},
 	{inputWithMultipleSpacesAfterH2},
+	{inputWithLineBreaksBetweenRules},
+	{inputWithLineBreaksBeforeAndAfter},
+	{inputWithLineBreaksBetweenRulesAndSpecs},
+	{inputWithLineBreakAfterFooter},
 }
 
 func TestSpecsHeaderContract(t *testing.T) {
@@ -53,7 +110,6 @@ func TestSpecsHeaderContract(t *testing.T) {
 		issue := issue{nil, ""}
 		expected := `
 This is a description of an issue.
-
 More description after the specs.`
 		actual, _ := issue.removeSpecsFrom(tt.input)
 

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -1,0 +1,12 @@
+// Package regex implements simple regex utility functions
+package regex
+
+import (
+	"regexp"
+)
+
+// CountMatches counts the number of matches of regex in s.
+func CountMatches(s, regex string) int {
+	matches := regexp.MustCompile(regex).FindAllStringIndex(s, -1)
+	return len(matches)
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jira",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "name": "Jira",
     "description": "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
Sometimes when a Jira issue is edited manually it will lead to headings
(e.g. in the description field) either having a space or not having a
space between the heading and the heading text.
The bug was caused by us always expecting the Gauge specs section
in the Jira to have an h2 heading with no space between the h2 and
the heading text.  This pull request fixes that bug by handling both 
scenarios - we now allow for there to be no space, or any number of 
spaces.

This PR also caters for a situation where the whitespace in the Gauge
specifications section of the Jira issue description changes (e.g. if
a manual edit to the issue description inadvertently changes it).
Prior to this commit that would cause the Gauge specs section to be
duplicated (rather than being replaced as it should), on the next
running of the Gauge Jira plugin.

The PR also fixes an occasional bug in the formatting of the footer
of the Gauge specs section in Jira.  Sometimes the footer was being
erroneously indented, e.g. if the specs finished with a table.
The PR fixes the bug by adding a newline at the beginning of the
footer.