### PR TITLE
Add link to each spec's Git URL

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -58,9 +58,10 @@ jobs:
 
       - name: ${{ matrix.jira-version }} FTs
         env:
-          JIRA_BASE_URL: ${{secrets[matrix.jira-base-url]}}
-          JIRA_USERNAME: ${{secrets[matrix.jira-username]}}
-          JIRA_TOKEN: ${{secrets[matrix.jira-token]}}
+          JIRA_BASE_URL: ${{ secrets[matrix.jira-base-url] }}
+          JIRA_USERNAME: ${{ secrets[matrix.jira-username] }}
+          JIRA_TOKEN: ${{ secrets[matrix.jira-token] }}
+          SPECS_GIT_URL: ${{ secrets.SPECS_GIT_URL }}
         run: |
           cd functional-tests
           ./gradlew clean ft

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you find a problem with a particular version of Jira Server or Jira Cloud, pl
 
 ### Plugin setup
 
-There are three variables to configure, as either:
+There are four variables to configure, as either:
 
 1. environment variables
 
@@ -92,7 +92,7 @@ There are three variables to configure, as either:
    [properties file](https://docs.gauge.org/configuration.html#local-configuration-of-gauge-default-properties),
    e.g. `<project_root>/env/default/anythingyoulike.properties`
 
-The three variables to configure are:
+The four variables to configure are:
 
 `JIRA_BASE_URL` e.g. `https://example.com` for Jira Server, or `https://example.atlassian.net` for Jira Cloud
 
@@ -101,6 +101,11 @@ This user must have permissions to edit issues in the Jira projects that the spe
 
 `JIRA_TOKEN` The Jira token is the password for the given `JIRA_USERNAME` if using Jira Server, or an
 [api token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html) if using Jira Cloud.
+
+`SPECS_GIT_URL` e.g. https://github.com/agilepathway/gauge-jira/tree/master/functional-tests/specs 
+: the full URL for the specs directory for your project on e.g. GitHub, GitLab, Bitbucket etc. 
+Used to create links in the Jira issues back to the specs' Git source files.  The URL can end with or 
+without a space.
 
 
 ### Running the plugin (i.e. publishing specs to Jira)

--- a/functional-tests/specs/check_config_vars.spec
+++ b/functional-tests/specs/check_config_vars.spec
@@ -12,3 +12,5 @@ tags: java, dotnet, ruby, python, js
 
 * Required configuration variable "JIRA_TOKEN" must be set
 
+* Required configuration variable "SPECS_GIT_URL" must be set
+

--- a/functional-tests/specs/two_specs_dirs.spec
+++ b/functional-tests/specs/two_specs_dirs.spec
@@ -1,0 +1,15 @@
+# Only one specs directory can be provided
+
+tags: java, dotnet, ruby, python, js
+
+Gauge documentation plugins allow for multiple specs directories to be passed in as command-line
+arguments.  Our Jira plugin can only accept one though, as we match up the specs directory with
+the specs Git URL that is also provided by the plugin user.
+
+* Initialize an empty Gauge project
+
+## The plugin fails if more than one specs directory is provided
+
+* Publish Jira Documentation for two projects
+
+* Console should contain "Aborting: this plugin only accepts one specs directory as a command-line argument."

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
@@ -195,17 +195,29 @@ public abstract class GaugeProject {
     }
 
     public ExecutionSummary publishJiraDocumentation() throws Exception {
-        return publishJiraDocumentation(null);
+        return publishJiraDocumentation(Map.of());
     }
 
-    public ExecutionSummary publishJiraDocumentation(Map<String, String> envVars) throws Exception {
-        String[] args = new String[] { "docs", "jira", "specs/" };
+    public ExecutionSummary publishJiraDocumentation(String[] args, Map<String, String> envVars) throws Exception {
         boolean success = executeGaugeCommand(args, envVars);
         return new ExecutionSummary(String.join(" ", args), success, lastProcessStdout, lastProcessStderr);
     }
 
+    public ExecutionSummary publishJiraDocumentation(Map<String, String> envVars) throws Exception {
+        return publishJiraDocumentation(new String[] { "docs", "jira", "specs/" }, envVars);
+    }
+
     public ExecutionSummary publishJiraDocumentationWithConfigVarUnset(String configVar) throws Exception {
         return publishJiraDocumentation(Map.of(configVar, ""));
+    }
+
+    public ExecutionSummary publishJiraDocumentationForTwoProjects() throws Exception {
+        String[] args = new String[] { "docs", "jira", "specs1", "specs2" };
+        return publishJiraDocumentation(args);
+    }
+
+    public ExecutionSummary publishJiraDocumentation(String[] args) throws Exception {
+        return publishJiraDocumentation(args, Map.of());
     }
 
     private boolean executeGaugeCommand(String[] args, Map<String, String> envVars)

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
@@ -27,4 +27,9 @@ public class Execution {
     public void publishJiraDocumentationForCurrentProjectWithConfigVarUnset(String configVar) throws Exception {
         assertOn(getCurrentProject().publishJiraDocumentationWithConfigVarUnset(configVar), false);
     }
+
+    @Step("Publish Jira Documentation for two projects")
+    public void publishJiraDocumentationForTwoProjects() throws Exception {
+        assertOn(getCurrentProject().publishJiraDocumentationForTwoProjects(), false);
+    }
 }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/jira/Jira.java
@@ -67,7 +67,7 @@ public class Jira {
                 ----
                 ----
                 h2.Specification Examples
-                h3.Do not edit these examples here.  Edit them using Gauge.
+                h3.Edit these examples in Git (link is below), not here in Jira
                 """;
     }
 
@@ -90,11 +90,13 @@ public class Jira {
     private String expectedBasicScenarioHeader(String scenarioName) {
         return """
                 ----
-                h3. %s
+                h3. %1$s
+                [View or edit this spec in Git|%2$s/%1$s.spec]
+
 
                 tags:\040
 
-                """.formatted(scenarioName);
+                """.formatted(scenarioName, System.getenv("SPECS_GIT_URL"));
     }
 
     private String expectedBasicSpec() {

--- a/internal/jira/issue.go
+++ b/internal/jira/issue.go
@@ -15,18 +15,21 @@ const (
 	specsHeaderMessageRegex = "h2.\\s*" + specsHeaderMessage
 	specsHeader             = "\n----\n----\nh2." + specsHeaderMessage + "\n"
 	specsHeaderRegex        = "\\s*----\\s*----\\s*" + specsHeaderMessageRegex + "\\s*"
-	specsSubheader          = "h3.Do not edit these examples here.  Edit them using Gauge.\n"
 	specsFooter             = "\n----\nEnd of specification examples\n----\n----\n"
 	specsFooterRegex        = "\\s*----\\s*End of specification examples\\s*----\\s*----\\s*"
 )
 
 type issue struct {
-	specs []spec
+	specs []Spec
 	key   string
 }
 
-func (i *issue) addSpec(spec spec) {
+func (i *issue) addSpec(spec Spec) {
 	i.specs = append(i.specs, spec)
+}
+
+func (i *issue) specsSubheader() string {
+	return "h3.Edit these examples in Git (link is below), not here in Jira\n"
 }
 
 func (i *issue) specsFormattedForJira() (string, error) {
@@ -36,7 +39,7 @@ func (i *issue) specsFormattedForJira() (string, error) {
 	}
 
 	return json.Fmt(currentDescriptionWithExistingSpecsRemoved +
-		specsHeader + specsSubheader + i.jiraFmtSpecs() + specsFooter), nil
+		specsHeader + i.specsSubheader() + i.jiraFmtSpecs() + specsFooter), nil
 }
 
 func (i *issue) jiraFmtSpecs() string {

--- a/internal/jira/issues.go
+++ b/internal/jira/issues.go
@@ -13,19 +13,19 @@ func newIssues() issues {
 	return make(map[string]issue)
 }
 
-func (i issues) addSpecs(specFilenames []string) {
-	for _, filename := range specFilenames {
-		i.addSpecToAllItsLinkedIssues(newSpec(filename))
+func (i issues) addSpecs(specs []Spec) {
+	for _, spec := range specs {
+		i.addSpecToAllItsLinkedIssues(spec)
 	}
 }
 
-func (i issues) addSpecToAllItsLinkedIssues(spec spec) {
+func (i issues) addSpecToAllItsLinkedIssues(spec Spec) {
 	for _, issueKey := range spec.issueKeys() {
 		i.addSpecToIssue(spec, issueKey)
 	}
 }
 
-func (i issues) addSpecToIssue(spec spec, issueKey string) {
+func (i issues) addSpecToIssue(spec Spec, issueKey string) {
 	issue := i[issueKey]
 	if issue.key == "" {
 		issue.key = issueKey

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -8,9 +8,9 @@ import (
 )
 
 // PublishSpecs publishes the given Gauge specifications to Jira
-func PublishSpecs(specFilenames []string) {
+func PublishSpecs(specs []Spec) {
 	issues := newIssues()
-	issues.addSpecs(specFilenames)
+	issues.addSpecs(specs)
 	issues.publish()
 }
 

--- a/internal/jira/spec.go
+++ b/internal/jira/spec.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/agilepathway/gauge-jira/internal/env"
+	"github.com/agilepathway/gauge-jira/internal/regex"
 	"github.com/agilepathway/gauge-jira/util"
 )
 
@@ -34,17 +35,8 @@ func (s *Spec) jiraFmt() string {
 }
 
 func (s *Spec) addGitLinkAfterSpecHeading(spec string) string {
-	pattern := regexp.MustCompile(`(h1.*)`)
-	isFirstMatch := true
-	output := pattern.ReplaceAllStringFunc(spec, func(match string) string {
-		if isFirstMatch { // only insert the Git link if it is the first h1 match
-			isFirstMatch = false
-			return pattern.ReplaceAllString(match, fmt.Sprintf("${1}\n%s\n", s.gitLinkInJiraFormat()))
-		}
-		return match // this is not the first match, so return the match unchanged
-	})
-
-	return output
+	replacement := fmt.Sprintf("${1}\n%s\n", s.gitLinkInJiraFormat())
+	return regex.ReplaceFirstMatch(spec, replacement, regexp.MustCompile(`(h1.*)`))
 }
 
 func (s *Spec) gitLinkInJiraFormat() string {

--- a/internal/jira/spec.go
+++ b/internal/jira/spec.go
@@ -3,7 +3,6 @@ package jira
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 
@@ -14,13 +13,14 @@ import (
 
 // Spec decorates a Gauge specification so it can be published to Jira.
 type Spec struct {
-	absolutePath string
-	markdown     string
+	absolutePath       string // absolute path to the specification file, including the filename
+	specsBaseDirectory string // specs directory which contains all the specs
+	markdown           string // the spec contents
 }
 
 // NewSpec returns a new Spec object for the spec at the given absolute path
-func NewSpec(absolutePath string) Spec {
-	return Spec{absolutePath, readMarkdown(absolutePath)}
+func NewSpec(absolutePath string, specsBaseDirectory string) Spec {
+	return Spec{absolutePath, specsBaseDirectory, readMarkdown(absolutePath)}
 }
 
 func (s *Spec) issueKeys() []string {
@@ -50,8 +50,9 @@ func (s *Spec) gitURL() string {
 		strings.TrimPrefix(s.relativePath(), "/")
 }
 
+// relativePath is the path from the specs base directory to the spec file, including the filename
 func (s *Spec) relativePath() string {
-	return strings.TrimPrefix(s.absolutePath, os.Getenv("GAUGE_SPEC_DIRS"))
+	return strings.TrimPrefix(s.absolutePath, s.specsBaseDirectory)
 }
 
 func (s *Spec) downsizeHeadings(spec string) string {

--- a/internal/jira/spec.go
+++ b/internal/jira/spec.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/agilepathway/gauge-jira/internal/env"
 	"github.com/agilepathway/gauge-jira/internal/regex"
 	"github.com/agilepathway/gauge-jira/util"
 )
@@ -16,11 +15,12 @@ type Spec struct {
 	absolutePath       string // absolute path to the specification file, including the filename
 	specsBaseDirectory string // specs directory which contains all the specs
 	markdown           string // the spec contents
+	specsGitURL        string // the URL for the specs directory on e.g. GitHub, GitLab
 }
 
 // NewSpec returns a new Spec object for the spec at the given absolute path
-func NewSpec(absolutePath string, specsBaseDirectory string) Spec {
-	return Spec{absolutePath, specsBaseDirectory, readMarkdown(absolutePath)}
+func NewSpec(absolutePath string, specsBaseDirectory string, specsGitURL string) Spec {
+	return Spec{absolutePath, specsBaseDirectory, readMarkdown(absolutePath), specsGitURL}
 }
 
 func (s *Spec) issueKeys() []string {
@@ -45,7 +45,7 @@ func (s *Spec) gitLinkInJiraFormat() string {
 
 func (s *Spec) gitURL() string {
 	// ensure that we have the right number of slashes
-	return strings.TrimSuffix(env.GetRequired("SPECS_GIT_URL"), "/") +
+	return strings.TrimSuffix(s.specsGitURL, "/") +
 		"/" +
 		strings.TrimPrefix(s.relativePath(), "/")
 }

--- a/internal/jira/spec.go
+++ b/internal/jira/spec.go
@@ -3,39 +3,75 @@ package jira
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
+	"strings"
 
+	"github.com/agilepathway/gauge-jira/internal/env"
 	"github.com/agilepathway/gauge-jira/util"
 )
 
-type spec struct {
-	filename string
-	markdown string
+// Spec decorates a Gauge specification so it can be published to Jira.
+type Spec struct {
+	absolutePath string
+	markdown     string
 }
 
-func newSpec(filename string) spec {
-	return spec{filename, readMarkdown(filename)}
+// NewSpec returns a new Spec object for the spec at the given absolute path
+func NewSpec(absolutePath string) Spec {
+	return Spec{absolutePath, readMarkdown(absolutePath)}
 }
 
-func (s *spec) issueKeys() []string {
+func (s *Spec) issueKeys() []string {
 	return parseIssueKeys(s.markdown)
 }
 
-func (s *spec) jiraFmt() string {
-	jiraFormatted := mdToJira(s.markdown)
-	return "----\n" + s.downsizeHeadings(jiraFormatted)
+func (s *Spec) jiraFmt() string {
+	jiraFormattedSpec := mdToJira(s.markdown)
+	jiraFormattedSpecWithGitLink := s.addGitLinkAfterSpecHeading(jiraFormattedSpec)
+
+	return "----\n" + s.downsizeHeadings(jiraFormattedSpecWithGitLink)
 }
 
-func (s *spec) downsizeHeadings(input string) string {
-	input = regexp.MustCompile(`h1\.`).ReplaceAllString(input, "h3.")
-	input = regexp.MustCompile(`h2\.`).ReplaceAllString(input, "h4.")
+func (s *Spec) addGitLinkAfterSpecHeading(spec string) string {
+	pattern := regexp.MustCompile(`(h1.*)`)
+	isFirstMatch := true
+	output := pattern.ReplaceAllStringFunc(spec, func(match string) string {
+		if isFirstMatch { // only insert the Git link if it is the first h1 match
+			isFirstMatch = false
+			return pattern.ReplaceAllString(match, fmt.Sprintf("${1}\n%s\n", s.gitLinkInJiraFormat()))
+		}
+		return match // this is not the first match, so return the match unchanged
+	})
 
-	return input
+	return output
 }
 
-func readMarkdown(filename string) string {
-	specBytes, err := ioutil.ReadFile(filename) //nolint:gosec
-	util.Fatal(fmt.Sprintf("Error while reading %s file", filename), err)
+func (s *Spec) gitLinkInJiraFormat() string {
+	return fmt.Sprintf("[View or edit this spec in Git|%s]", s.gitURL())
+}
+
+func (s *Spec) gitURL() string {
+	// ensure that we have the right number of slashes
+	return strings.TrimSuffix(env.GetRequired("SPECS_GIT_URL"), "/") +
+		"/" +
+		strings.TrimPrefix(s.relativePath(), "/")
+}
+
+func (s *Spec) relativePath() string {
+	return strings.TrimPrefix(s.absolutePath, os.Getenv("GAUGE_SPEC_DIRS"))
+}
+
+func (s *Spec) downsizeHeadings(spec string) string {
+	spec = regexp.MustCompile(`h1\.`).ReplaceAllString(spec, "h3.")
+	spec = regexp.MustCompile(`h2\.`).ReplaceAllString(spec, "h4.")
+
+	return spec
+}
+
+func readMarkdown(absolutePath string) string {
+	specBytes, err := ioutil.ReadFile(absolutePath) //nolint:gosec
+	util.Fatal(fmt.Sprintf("Error while reading %s file", absolutePath), err)
 
 	return string(specBytes)
 }

--- a/internal/jira/spec_test.go
+++ b/internal/jira/spec_test.go
@@ -2,12 +2,12 @@ package jira
 
 import (
 	"fmt"
-	"os"
 	"testing"
 )
 
 const (
 	specsBaseDirectory = "/home/vscode/workspace/gauge-jira/functional_tests/specs/"
+	specsGitURL        = "https://github.com/agilepathway/gauge-jira/tree/master/functional-tests/specs"
 	exampleFilename    = "example.spec"
 	defaultExampleSpec = `
 ----
@@ -65,10 +65,11 @@ var specTests = []struct { //nolint:gochecknoglobals
 //nolint:errcheck,gosec
 func TestAddGitLinkAfterSpecHeading(t *testing.T) {
 	for _, tt := range specTests {
-		os.Setenv("SPECS_GIT_URL", "https://github.com/agilepathway/gauge-jira/tree/master/functional-tests/specs")
-
-		spec := Spec{absolutePath: specsBaseDirectory + tt.filename, specsBaseDirectory: specsBaseDirectory, markdown: ""}
-		expected := fmt.Sprintf(tt.expected, os.Getenv("SPECS_GIT_URL"), tt.filename)
+		spec := Spec{
+			absolutePath:       specsBaseDirectory + tt.filename,
+			specsBaseDirectory: specsBaseDirectory,
+			specsGitURL:        specsGitURL}
+		expected := fmt.Sprintf(tt.expected, specsGitURL, tt.filename)
 		actual := spec.addGitLinkAfterSpecHeading(tt.input)
 
 		if expected != actual {

--- a/internal/jira/spec_test.go
+++ b/internal/jira/spec_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	absolutePath       = "/home/vscode/workspace/gauge-jira/functional_tests/specs/"
+	specsBaseDirectory = "/home/vscode/workspace/gauge-jira/functional_tests/specs/"
 	exampleFilename    = "example.spec"
 	defaultExampleSpec = `
 ----
@@ -65,10 +65,9 @@ var specTests = []struct { //nolint:gochecknoglobals
 //nolint:errcheck,gosec
 func TestAddGitLinkAfterSpecHeading(t *testing.T) {
 	for _, tt := range specTests {
-		os.Setenv("GAUGE_SPEC_DIRS", absolutePath)
 		os.Setenv("SPECS_GIT_URL", "https://github.com/agilepathway/gauge-jira/tree/master/functional-tests/specs")
 
-		spec := Spec{absolutePath: absolutePath + tt.filename, markdown: ""}
+		spec := Spec{absolutePath: specsBaseDirectory + tt.filename, specsBaseDirectory: specsBaseDirectory, markdown: ""}
 		expected := fmt.Sprintf(tt.expected, os.Getenv("SPECS_GIT_URL"), tt.filename)
 		actual := spec.addGitLinkAfterSpecHeading(tt.input)
 

--- a/internal/jira/spec_test.go
+++ b/internal/jira/spec_test.go
@@ -1,0 +1,84 @@
+package jira
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+const (
+	absolutePath       = "/home/vscode/workspace/gauge-jira/functional_tests/specs/"
+	exampleFilename    = "example.spec"
+	defaultExampleSpec = `
+----
+h1. This is the spec heading
+
+h2. This is a scenario
+`
+	expectedDefaultExampleSpec = `
+----
+h1. This is the spec heading
+[View or edit this spec in Git|%s/%s]
+
+
+h2. This is a scenario
+`
+	linebreakBetweenHeadingAndScenario         = defaultExampleSpec
+	expectedLinebreakBetweenHeadingAndScenario = expectedDefaultExampleSpec
+	noLineBreakBetweenHeadingAndScenario       = `
+----
+h1. This is the spec heading
+h2. This is a scenario
+`
+	expectedNoLineBreakBetweenHeadingAndScenario = `
+----
+h1. This is the spec heading
+[View or edit this spec in Git|%s/%s]
+
+h2. This is a scenario
+`
+	h1TextInScenario = `
+----
+h1. This is the spec heading
+h2. This is a scenario which has the text h1. in it
+`
+	expectedh1TextInScenario = `
+----
+h1. This is the spec heading
+[View or edit this spec in Git|%s/%s]
+
+h2. This is a scenario which has the text h1. in it
+`
+)
+
+var specTests = []struct { //nolint:gochecknoglobals
+	input    string
+	expected string
+	filename string
+}{
+	{linebreakBetweenHeadingAndScenario, expectedLinebreakBetweenHeadingAndScenario, exampleFilename},
+	{noLineBreakBetweenHeadingAndScenario, expectedNoLineBreakBetweenHeadingAndScenario, exampleFilename},
+	{h1TextInScenario, expectedh1TextInScenario, exampleFilename},
+	{defaultExampleSpec, expectedDefaultExampleSpec, "filename_with_the_word_specs.spec"},
+}
+
+//nolint:errcheck,gosec
+func TestAddGitLinkAfterSpecHeading(t *testing.T) {
+	for _, tt := range specTests {
+		os.Setenv("GAUGE_SPEC_DIRS", absolutePath)
+		os.Setenv("SPECS_GIT_URL", "https://github.com/agilepathway/gauge-jira/tree/master/functional-tests/specs")
+
+		spec := Spec{absolutePath: absolutePath + tt.filename, markdown: ""}
+		expected := fmt.Sprintf(tt.expected, os.Getenv("SPECS_GIT_URL"), tt.filename)
+		actual := spec.addGitLinkAfterSpecHeading(tt.input)
+
+		if expected != actual {
+			t.Fatalf(`
+	Expected
+	%s
+	
+	but got:
+	%s`, expected, actual)
+		}
+	}
+}

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -6,7 +6,24 @@ import (
 )
 
 // CountMatches counts the number of matches of regex in s.
-func CountMatches(s, regex string) int {
-	matches := regexp.MustCompile(regex).FindAllStringIndex(s, -1)
+func CountMatches(s, pattern string) int {
+	matches := regexp.MustCompile(pattern).FindAllStringIndex(s, -1)
 	return len(matches)
+}
+
+// ReplaceFirstMatch returns a copy of src, replacing the first match of the
+// Regexp pattern with the replacement string repl. Inside repl, $ signs are
+// interpreted as in Expand, so for instance $1 represents the text of the
+// first submatch.
+func ReplaceFirstMatch(src, repl string, pattern *regexp.Regexp) string {
+	isFirstMatch := true
+	output := pattern.ReplaceAllStringFunc(src, func(match string) string {
+		if isFirstMatch { // only do the replacing if it is the first match
+			isFirstMatch = false
+			return pattern.ReplaceAllString(match, repl)
+		}
+		return match // this is not the first match, so return the match unchanged
+	})
+
+	return output
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func (h *handler) GenerateDocs(c context.Context, m *gauge_messages.SpecDetails)
 	specsAbsolutePaths = append(specsAbsolutePaths, util.GetFiles(specsDirectoryPath)...)
 
 	for _, absolutePath := range specsAbsolutePaths {
-		specs = append(specs, jira.NewSpec(absolutePath, specsDirectoryPath))
+		specs = append(specs, jira.NewSpec(absolutePath, specsDirectoryPath, env.GetRequired("SPECS_GIT_URL")))
 	}
 
 	jira.PublishSpecs(specs)

--- a/main.go
+++ b/main.go
@@ -26,12 +26,20 @@ type handler struct {
 }
 
 func (h *handler) GenerateDocs(c context.Context, m *gauge_messages.SpecDetails) (*gauge_messages.Empty, error) {
-	var specFilenames []string //nolint:prealloc
+	var ( //nolint:prealloc
+		specsAbsolutePaths []string
+		specs              []jira.Spec
+	)
+
 	for _, arg := range strings.Split(os.Getenv(gaugeSpecsDir), fileSeparator) {
-		specFilenames = append(specFilenames, util.GetFiles(arg)...)
+		specsAbsolutePaths = append(specsAbsolutePaths, util.GetFiles(arg)...)
 	}
 
-	jira.PublishSpecs(specFilenames)
+	for _, absolutePath := range specsAbsolutePaths {
+		specs = append(specs, jira.NewSpec(absolutePath))
+	}
+
+	jira.PublishSpecs(specs)
 
 	return &gauge_messages.Empty{}, nil
 }
@@ -68,4 +76,5 @@ func checkRequiredConfigVars() {
 	env.GetRequired("JIRA_BASE_URL")
 	env.GetRequired("JIRA_USERNAME")
 	env.GetRequired("JIRA_TOKEN")
+	env.GetRequired("SPECS_GIT_URL")
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jira",
-    "version": "0.1.8",
+    "version": "0.2.0",
     "name": "Jira",
     "description": "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
This commit adds a a link from each Gauge spec published
in Jira by the plugin back to the spec's source file in Git (on
one of e.g. GitHub, Gitlab, Bitbucket etc).

This is a breaking change, as it requires a new mandatory
`SPECS_GIT_URL`configuration variable to be provided.