### PR TITLE
Fix Codespace devcontainer project root variable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 			"--fast"
 		],
 		"go.testEnvVars": {
-			"GAUGE_PROJECT_ROOT": "/home/vscode/workspace/gauge-jira"
+			"GAUGE_PROJECT_ROOT": "${containerWorkspaceFolder}"
 		},
 		"files.autoSave": "afterDelay",
 		"files.autoSaveDelay": 500,
@@ -37,7 +37,7 @@
 		"vscjava.vscode-java-pack"
 	],
 	"containerEnv": {
-		"GAUGE_PROJECT_ROOT": "/home/vscode/workspace/gauge-jira"
+		"GAUGE_PROJECT_ROOT": "${containerWorkspaceFolder}"
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jira",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "name": "Jira",
     "description": "Publishes Gauge specifications to Jira",
     "install": {


### PR DESCRIPTION
This is an internal development environment only change - no change to
the plugin's production code.

The directory that GitHub Codespaces opens in changed recently, (e.g. to
`workspaces/gauge-jira` for this project) in a recent update to
Codespaces.

This meant that the unit tests were failing when run from within the
Codespace, because the required `GAUGE_PROJECT_ROOT`
environment variable was now pointing to the wrong directory.

Happily the fix in this commit means that we now define the
`GAUGE_PROJECT_ROOT` variable dynamically when setting up the Codespace
devcontainer, based on the [`containerWorkspaceFolder` value][1].

The [VSCode devcontainer documentation at the time of this commit still
says that `containerWorkspaceFolder` is not supported within
Codespaces][1], so the guess is that either this capability was recently
added to Codespaces and the documentation has not been updated yet, or
that it has always been possible to _read_ the
`containerWorkspaceFolder` value, just not to write it.
    
[1]: https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_variables-in-devcontainerjson